### PR TITLE
Fixed Auth Timeout Issue

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -57,6 +57,7 @@ type Mutation {
 }
 
 type Query {
+  allApprentices: [User!]!
   allUsers: [User!]!
   getAllCategories: [Category!]!
   getCategoryByID(categoryID: String!): Category!

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -84,11 +84,12 @@ export class AuthService {
   }
 
   generateToken(payload: UserPayload): Token {
-    const accessToken = this.jwtService.sign(payload);
+    const accessToken = this.jwtService.sign(payload, {
+      expiresIn: "2 days",
+    });
 
-    const securityConfig = this.configService.get<SecurityConfig>('security');
     const refreshToken = this.jwtService.sign(payload, {
-      expiresIn: securityConfig.refreshIn,
+      expiresIn: "2 days",
     });
 
     return {


### PR DESCRIPTION
Added an `expiresIn` option on the token creation. The token won't expire for two days now.